### PR TITLE
fix runner reference from chart values

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ FROM okteto/pipeline-runner:1.0.0
 and configure your custom image in the okteto chart values file like this:
 
 ```
-backend:
-  installer:
-    image: okteto/pipeline-runner:1.0.0
+installer:
+  runner: okteto/pipeline-runner:1.0.0
 ```
 
 replacing `okteto/pipeline-runner:1.0.0` by your own pipeline runner image.


### PR DESCRIPTION
Readme was having the old reference for replacing the pipeline runner image.

After https://github.com/okteto/app/pull/4252 the correct values for installer configuration are reference under `installer` section of chart values

https://www.okteto.com/docs/self-hosted/administration/configuration/#installer 
