### PR TITLE
Fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 FROM debian:bullseye-slim
 
-COPY --from=cuelang/cue:0.4.0 /usr/bin/cue /usr/local/bin/cue
+COPY --from=cuelang/cue:0.5.0 /usr/bin/cue /usr/local/bin/cue
 COPY --from=mikefarah/yq:4 /usr/bin/yq /usr/local/bin/yq
 
 RUN apt update && \


### PR DESCRIPTION
Resolves https://github.com/okteto/app/issues/6576

- Updated image cuelang/cue to 0.5.0
- debian:bullseye-slim is updated from debian 11.6 to 11.7 which also fixes some CVE
