### PR TITLE
Update base image to debian 12 (bookworm)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     docker:
       - image: cimg/base:2022.03-20.04
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - setup_remote_docker:
@@ -29,7 +29,7 @@ jobs:
   release_latest:
     docker:
       - image: cimg/base:2022.03-20.04
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,10 @@ jobs:
   test:
     docker:
       - image: cimg/base:2022.03-20.04
-    resource_class: medium
+    resource_class: small
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.6
+      - setup_remote_docker
       - run: 
           name: Build image
           command: docker build -t okteto/pipeline-runner:test .
@@ -18,8 +17,7 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.6
+      - setup_remote_docker
       - run:
           name: Build and Push Pipeline Installer Image
           command: |
@@ -29,11 +27,10 @@ jobs:
   release_latest:
     docker:
       - image: cimg/base:2022.03-20.04
-    resource_class: medium
+    resource_class: small
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.6
+      - setup_remote_docker
       - run:
           name: Build and Push Pipeline Installer Image
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bookworm-slim
 COPY --from=cuelang/cue:0.5.0 /usr/bin/cue /usr/local/bin/cue
 COPY --from=mikefarah/yq:4 /usr/bin/yq /usr/local/bin/yq
 
-RUN apt update && \
+RUN apt update && apt clean && \
     apt -y install \
         sudo \
         apt-transport-https \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bookworm-slim
 COPY --from=cuelang/cue:0.5.0 /usr/bin/cue /usr/local/bin/cue
 COPY --from=mikefarah/yq:4 /usr/bin/yq /usr/local/bin/yq
 
-RUN apt update && apt clean && \
+RUN apt clean && apt update && \
     apt -y install \
         sudo \
         apt-transport-https \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 COPY --from=cuelang/cue:0.5.0 /usr/bin/cue /usr/local/bin/cue
 COPY --from=mikefarah/yq:4 /usr/bin/yq /usr/local/bin/yq
@@ -18,4 +18,4 @@ RUN apt update && \
         gettext-base \
         wait-for-it \
         jq \
-        netcat
+        netcat-traditional


### PR DESCRIPTION
Upgrade base image to Debian 12 which fixes a lot of vulnerabilies.

Before:

```
Total: 253 (UNKNOWN: 0, LOW: 175, MEDIUM: 22, HIGH: 52, CRITICAL: 4)
```

After:

```
Total: 167 (UNKNOWN: 0, LOW: 147, MEDIUM: 7, HIGH: 10, CRITICAL: 3)
```


