### PR TITLE
Updating cue to v0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 FROM debian:bookworm-slim
 
-COPY --from=cuelang/cue:0.5.0 /usr/bin/cue /usr/local/bin/cue
+COPY --from=cuelang/cue:0.6.0 /usr/bin/cue /usr/local/bin/cue
 COPY --from=mikefarah/yq:4 /usr/bin/yq /usr/local/bin/yq
 
 RUN apt clean && apt update && \


### PR DESCRIPTION
The previous version contained critical and high severity issues in an old version of golang.org/x/net.