### PR TITLE
Updated dependency for cue and rebuild image to fix some CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 FROM debian:bookworm-slim
 
-COPY --from=cuelang/cue:0.5.0 /usr/bin/cue /usr/local/bin/cue
+COPY --from=cuelang/cue:0.9.2 /usr/bin/cue /usr/local/bin/cue
 COPY --from=mikefarah/yq:4 /usr/bin/yq /usr/local/bin/yq
 
 RUN apt clean && apt update && \


### PR DESCRIPTION
While I was reviewing CVEs in general, I saw that pipeline-runner has several vulnerabilities that can be solved. Not all of them can be solved as some CRITICAL depends on the git version installed on Debian. The stable version of `git`  installed in Debian is `1:2.39.2-1.1`, which contains some vulnerabilities. You can see the git package information in Debian [here](https://tracker.debian.org/pkg/git).

At least, rebuilding the image and updating the `cue` dependency, we remove 6 CRITICAL and several HIGH, so it is at least an improvement. 

I will be testing it on my dev environment

Before the changes:

`Total: 337 (UNKNOWN: 0, LOW: 170, MEDIUM: 81, HIGH: 75, CRITICAL: 11)`

After the changes:

`Total: 229 (UNKNOWN: 0, LOW: 168, MEDIUM: 36, HIGH: 22, CRITICAL: 3)`
