### PR TITLE
fix: update image tags to use 'v' prefix for rootful and rootless builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,4 +51,4 @@ workflows:
               ignore: /.*/
             tags:
               only:
-                - /^\d+\.\d+\.\d+$/
+                - /^v\d+\.\d+\.\d+$/

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ build-rootless:
 push: push-rootful
 
 push-rootful:
-	okteto build -t okteto/pipeline-runner:v${CIRCLE_TAG} --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .
+	okteto build -t okteto/pipeline-runner:${CIRCLE_TAG} --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .
 
 push-rootless:
-	okteto build -t okteto/pipeline-runner:v${CIRCLE_TAG}-rootless --platform linux/amd64,linux/arm64 -f Dockerfile --target rootless .
+	okteto build -t okteto/pipeline-runner:${CIRCLE_TAG}-rootless --platform linux/amd64,linux/arm64 -f Dockerfile --target rootless .
 
 push-dev-rootful:
 	okteto build -t okteto.dev/pipeline-runner:dev --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ build-rootless:
 push: push-rootful
 
 push-rootful:
-	okteto build -t okteto/pipeline-runner:${CIRCLE_TAG} --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .
+	okteto build -t okteto/pipeline-runner:v${CIRCLE_TAG} --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .
 
 push-rootless:
-	okteto build -t okteto/pipeline-runner:${CIRCLE_TAG}-rootless --platform linux/amd64,linux/arm64 -f Dockerfile --target rootless .
+	okteto build -t okteto/pipeline-runner:v${CIRCLE_TAG}-rootless --platform linux/amd64,linux/arm64 -f Dockerfile --target rootless .
 
 push-dev-rootful:
 	okteto build -t okteto.dev/pipeline-runner:dev --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>