### PR TITLE
Remove jq and cue dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # syntax = docker/dockerfile:experimental
 FROM debian:bookworm-slim as base
 
-COPY --from=cuelang/cue:0.9.2 /usr/bin/cue /usr/local/bin/cue
-COPY --from=mikefarah/yq:4 /usr/bin/yq /usr/local/bin/yq
-
 RUN apt clean && apt update && \
     apt -y install \
         sudo \


### PR DESCRIPTION
As agreed upon, remove `jq` and `cue` as depedencies of pipeline executions