### PR TITLE
fix: standardize Dockerfile syntax for base image declaration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM debian:bookworm-slim as base
+FROM debian:bookworm-slim AS base
 
 RUN apt clean && apt update && \
     apt -y install \


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>