### PR TITLE
feat: enhance Git configuration in Dockerfile for improved performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ RUN apt clean && apt update && \
         jq \
         netcat-traditional
 
+RUN git config --global http.timeout 300 && \
+    git config --global http.lowSpeedLimit 1000 && \
+    git config --global http.lowSpeedTime 30 && \
+    git config --global core.sshCommand "ssh -o ConnectTimeout=300 -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o TCPKeepAlive=yes"
+
 FROM base as rootless
 
 RUN addgroup --gid 1000 runner && \


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>
Fixes DEV-1103
Git’s defaults don’t enforce a total HTTP timeout and allow very low throughput indefinitely, which can leave CI jobs stuck during stalls, flaky links, or partial outages without a clear error. A 300-second total timeout plus an abort when throughput stays below ~1 KB/s for 30 seconds turns silent hangs into explicit, bounded failures. SSH keepalives and a connection timeout help detect dead TCP sessions and NAT/idle timeouts during long clones or fetches, so the pipeline fails fast and surfaces a clear cause instead of hanging.