### PR TITLE
Rebuild image and cleanup commands to reduce image size and attack surface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM debian:bookworm-slim AS base
 
 RUN apt clean && apt update && \
+    apt -y upgrade && \
     apt -y install \
         sudo \
         apt-transport-https \
@@ -15,7 +16,10 @@ RUN apt clean && apt update && \
         gettext-base \
         wait-for-it \
         jq \
-        netcat-traditional
+        netcat-traditional && \
+    rm -f /etc/ssh/ssh_host_* && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN git config --global http.timeout 300 && \
     git config --global http.lowSpeedLimit 1000 && \

--- a/ai/fix-CVEs.md
+++ b/ai/fix-CVEs.md
@@ -1,0 +1,35 @@
+# Fix Backend CVEs
+
+Fix all vulnerabilities in the pipeline runner Docker image using systematic vulnerability scanning and remediation.
+
+## CONTEXT
+
+- The source code and Dockerfile for this image are in the root folder of the repo
+- The vulnerability scanning script is at `trivy/scan.sh`, referenced by the `okteto test trivy` test container
+- Focus on CRITICAL and HIGH severity vulnerabilities first, then address medium/low as needed
+
+## WORKFLOW
+
+### 1. Build and Scan Process
+
+- Rebuild the image: `okteto build` (do not use `--no-cache` unless necessary)
+- Scan for vulnerabilities: `okteto test trivy`
+- Analyze scan results to identify specific packages and CVEs that need attention
+
+### 2. Vulnerability Remediation
+
+- Repeat the build and scan process after each set of changes
+- Continue until all CRITICAL and HIGH vulnerabilities are resolved or you cannot fix more CVEs
+
+## PULL REQUEST REQUIREMENTS
+
+If you did any change, create a PR for vulnerability fixes
+
+### Required Content
+
+- **Clear status statement**: First line must clearly state whether ALL CRITICAL/HIGH vulnerabilities have been fixed or not
+- **Before/after scans**: Include trivy scan results before and after changes using:
+  ```
+  okteto test trivy
+  ```
+- **Summary of changes**: List specific packages updated, base image changes, etc.

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,0 +1,12 @@
+build:
+  image:
+    context: .
+
+test:
+  trivy:
+    image: aquasec/trivy:latest
+    context: trivy
+    caches:
+      - /root/.cache/trivy
+    commands:
+      - ./scan.sh

--- a/trivy/scan.sh
+++ b/trivy/scan.sh
@@ -14,4 +14,8 @@ scan_image() {
   fi
 }
 
-scan_image "registry.product.okteto.dev/pchico83/pipeline-runner-image:okteto"
+# Use IMAGE environment variable if provided, otherwise use default image
+DEFAULT_IMAGE="registry.product.okteto.dev/${AGENT_NAMESPACE}/pipeline-runner-image:okteto"
+IMAGE_TO_SCAN="${IMAGE:-$DEFAULT_IMAGE}"
+
+scan_image "$IMAGE_TO_SCAN"

--- a/trivy/scan.sh
+++ b/trivy/scan.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+export TRIVY_DISABLE_VEX_NOTICE=true
+
+scan_image() {
+  local image=$1
+  if [[ -n "$image" ]]; then
+    echo "🔍 Scanning image: $image"
+    trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress --severity CRITICAL,HIGH "$image"
+  else
+    echo "⚠️  Skipping empty image"
+  fi
+}
+
+scan_image "registry.product.okteto.dev/pchico83/pipeline-runner-image:okteto"


### PR DESCRIPTION
This PR has the folloowing changes:
- Create a "trivy" test container to let the Okteto Agent check for vulnerabilities
- Create a prompt to fix vulnerabilities on the pipeline runner image
- Fix some CVEs by running cleanup commands

There are still pending CVEs that are fixed by upgrading to Debian 13, but let's do that for the next Okteto release