### PR TITLE
chore: update debian image to debian 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax = docker/dockerfile:experimental
-FROM debian:bookworm-slim AS base
+FROM debian:trixie-slim AS base
 
 RUN apt clean && apt update && \
     apt -y upgrade && \
-    apt -y install \
+    apt -y install --no-install-recommends \
         sudo \
         apt-transport-https \
         ca-certificates \
@@ -19,7 +19,7 @@ RUN apt clean && apt update && \
         netcat-traditional && \
     rm -f /etc/ssh/ssh_host_* && \
     apt clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/*
 
 RUN git config --global http.timeout 300 && \
     git config --global http.lowSpeedLimit 1000 && \

--- a/trivy/scan.sh
+++ b/trivy/scan.sh
@@ -15,7 +15,7 @@ scan_image() {
 }
 
 # Use IMAGE environment variable if provided, otherwise use default image
-DEFAULT_IMAGE="registry.product.okteto.dev/${AGENT_NAMESPACE}/pipeline-runner-image:okteto"
+DEFAULT_IMAGE="registry.product.okteto.dev/${OKTETO_NAMESPACE}/pipeline-runner-image:okteto"
 IMAGE_TO_SCAN="${IMAGE:-$DEFAULT_IMAGE}"
 
 scan_image "$IMAGE_TO_SCAN"


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

- Updates base image to debian 13
- Fix trivy to be able to run after an okteto build