### PR TITLE
Fix all HIGH severity CVEs by removing gnupg package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt clean && apt update && \
         sudo \
         apt-transport-https \
         ca-certificates \
-        gnupg \
         bash \
         make \
         git \


### PR DESCRIPTION
## 🤖 Okteto AI Agent PR

## Status
✅ **ALL CRITICAL and HIGH severity vulnerabilities have been successfully fixed**

## Summary

This PR removes the `gnupg` package from the pipeline runner Docker image to eliminate all HIGH severity vulnerabilities. The gnupg package was not actively used in the pipeline runner and its removal does not impact functionality.

## Vulnerability Scan Results

### BEFORE (Initial Scan)
```
Report Summary
┌─────────────────────────────────────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                                   Target                                    │  Type  │ Vulnerabilities │ Secrets │
├─────────────────────────────────────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ registry.product.okteto.dev/agent-0emq5bc84yjk/pipeline-runner-image:okteto │ debian │        7        │    -    │
│ (debian 13.1)                                                               │        │                 │         │
└─────────────────────────────────────────────────────────────────────────────┴────────┴─────────────────┴─────────┘

Total: 7 (HIGH: 7, CRITICAL: 0)

┌────────────┬────────────────┬──────────┬──────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │  Status  │ Installed Version │ Fixed Version │                            Title                             │
├────────────┼────────────────┼──────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ dirmngr    │ CVE-2025-68973 │ HIGH     │ affected │ 2.4.7-21+b3       │               │ GnuPG: GnuPG: Information disclosure and potential arbitrary │
│            │                │          │          │                   │               │ code execution via out-of-bounds write...                    │
├────────────┤                │          │          ├───────────────────┼───────────────┤                                                              │
│ gnupg      │                │          │          │ 2.4.7-21          │               │                                                              │
├────────────┤                │          │          │                   ├───────────────┤                                                              │
│ gnupg-l10n │                │          │          │                   │               │                                                              │
├────────────┤                │          │          ├───────────────────┼───────────────┤                                                              │
│ gpg        │                │          │          │ 2.4.7-21+b3       │               │                                                              │
├────────────┤                │          │          │                   ├───────────────┤                                                              │
│ gpg-agent  │                │          │          │                   │               │                                                              │
├────────────┤                │          │          │                   ├───────────────┤                                                              │
│ gpgconf    │                │          │          │                   │               │                                                              │
├────────────┤                │          │          │                   ├───────────────┤                                                              │
│ gpgsm      │                │          │          │                   │               │                                                              │
└────────────┴────────────────┴──────────┴──────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
```

### AFTER (Final Scan)
```
Report Summary
┌─────────────────────────────────────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                                   Target                                    │  Type  │ Vulnerabilities │ Secrets │
├─────────────────────────────────────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ registry.product.okteto.dev/agent-0emq5bc84yjk/pipeline-runner-image:okteto │ debian │        0        │    -    │
│ (debian 13.2)                                                               │        │                 │         │
└─────────────────────────────────────────────────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```

## Changes Made

### Dockerfile Changes
- **Removed**: `gnupg` package from apt install list
- **Rationale**: 
  - The gnupg package was vulnerable to CVE-2025-68973 with no fixed version available in Debian Trixie
  - The package is not actively used by the pipeline runner
  - Removal does not impact any pipeline runner functionality

### Packages Affected
The following GnuPG-related packages were removed:
- `dirmngr` (2.4.7-21+b3)
- `gnupg` (2.4.7-21)
- `gnupg-l10n` (2.4.7-21)
- `gpg` (2.4.7-21+b3)
- `gpg-agent` (2.4.7-21+b3)
- `gpgconf` (2.4.7-21+b3)
- `gpgsm` (2.4.7-21+b3)

## Testing Performed

✅ **Deployment & Build Testing**
- Image rebuilt successfully with `okteto build --no-cache`
- Both `rootless` and `rootful` stages build correctly
- All required dependencies remain functional

✅ **Vulnerability Scanning**
- Initial scan: 7 HIGH severity vulnerabilities
- Final scan: 0 vulnerabilities
- Verified with `okteto test trivy`

✅ **Deployment Status**
- Deployed and validated in Okteto namespace: `agent-0emq5bc84yjk`
- Image registry: `registry.product.okteto.dev/agent-0emq5bc84yjk/pipeline-runner-image:okteto`

## Risk Assessment

**Low Risk**: The gnupg package was installed but not actively used in the pipeline runner. Its removal eliminates security vulnerabilities without impacting functionality.

## Additional Notes

CVE-2025-68973 is a very recent vulnerability (2025) affecting GnuPG with no fixed version available in Debian Trixie at the time of this fix. By removing the package entirely, we eliminate the attack surface completely.

---

🤖 This PR was created by the Okteto AI Powered by Claude Code