### PR TITLE
Fix CRITICAL and HIGH severity CVEs in pipeline runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt clean && apt update && \
         jq \
         netcat-traditional && \
     rm -f /etc/ssh/ssh_host_* && \
+    apt -y upgrade gnupg dirmngr gpg gpg-agent gpgconf gpgsm gnupg-l10n openssl libssl3t64 openssl-provider-legacy && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/*
 


### PR DESCRIPTION
🤖 Okteto AI Agent PR

## Status

✅ **16 out of 26 CRITICAL/HIGH vulnerabilities have been successfully fixed (61.5% reduction)**

❌ **10 vulnerabilities remain due to no upstream patches being available yet**

---

## Summary of Changes

This PR addresses security vulnerabilities in the pipeline runner Docker image by upgrading critical packages to their latest patched versions.

### Security Fixes Applied

#### CRITICAL CVEs Fixed (3 instances)
- **CVE-2025-15467** (OpenSSL): Remote code execution or DoS via oversized Initialization
  - Upgraded: `openssl`, `libssl3t64`, `openssl-provider-legacy` → `3.5.4-1~deb13u2`

#### HIGH CVEs Fixed (13 instances)
- **CVE-2025-68973** (GnuPG): Information disclosure and potential arbitrary code execution
  - Upgraded: `gnupg`, `dirmngr`, `gpg`, `gpg-agent`, `gpgconf`, `gpgsm`, `gnupg-l10n` → `2.4.7-21+deb13u1`
- **CVE-2025-69419** (OpenSSL): Arbitrary code execution via PKCS#12 processing
  - Upgraded: `openssl`, `libssl3t64`, `openssl-provider-legacy` → `3.5.4-1~deb13u2`
- **CVE-2025-69421** (OpenSSL): DoS via malformed PKCS#12 file processing
  - Upgraded: `openssl`, `libssl3t64`, `openssl-provider-legacy` → `3.5.4-1~deb13u2`

---

## Vulnerability Scan Results

### Before Changes
```
Total: 26 (HIGH: 22, CRITICAL: 4)

CRITICAL:
- CVE-2025-15467 (OpenSSL) - 3 packages
- CVE-2026-24515 (libexpat1) - 1 package

HIGH:
- CVE-2025-68973 (GnuPG) - 8 packages [FIXED]
- CVE-2026-24882 (GnuPG) - 8 packages
- CVE-2026-0861 (glibc) - 2 packages
- CVE-2025-69419 (OpenSSL) - 3 packages [FIXED]
- CVE-2025-69421 (OpenSSL) - 3 packages [FIXED]
```

### After Changes
```
Total: 10 (HIGH: 9, CRITICAL: 1)

CRITICAL:
- CVE-2026-24515 (libexpat1) - No fix available (affected)

HIGH:
- CVE-2026-24882 (GnuPG) - 7 packages - No fix available (affected)
- CVE-2026-0861 (glibc) - 2 packages - No fix available (affected)
```

**Improvement**: Reduced vulnerabilities from 26 to 10 (61.5% reduction)

---

## Remaining Vulnerabilities

The following vulnerabilities cannot be fixed at this time as no upstream patches are available:

1. **CVE-2026-24882** (GnuPG) - Stack-based buffer overflow in tpm2daemon
   - Affected packages: `gnupg`, `dirmngr`, `gpg`, `gpg-agent`, `gpgconf`, `gpgsm`, `gnupg-l10n`
   - Status: No fix available

2. **CVE-2026-0861** (glibc) - Integer overflow in memalign leads to heap corruption
   - Affected packages: `libc-bin`, `libc6`
   - Status: No fix available

3. **CVE-2026-24515** (libexpat1) - Null pointer dereference
   - Affected packages: `libexpat1`
   - Status: No fix available

---

## Technical Changes

### Dockerfile Modification
Added explicit package upgrade command for security-critical packages:
```dockerfile
apt -y upgrade gnupg dirmngr gpg gpg-agent gpgconf gpgsm gnupg-l10n openssl libssl3t64 openssl-provider-legacy
```

This ensures that during the Docker build, the latest security patches are fetched and installed from the Debian Trixie security repositories.

---

## Deployment Status

✅ **Deployed and validated in Okteto namespace**

- Built with: `okteto build --no-cache`
- Tested with: `okteto test trivy`
- All security scans completed successfully

---

## Next Steps

Monitor for upstream patches for the remaining CVEs:
- Subscribe to Debian security announcements
- Re-run vulnerability scans periodically
- Update packages when fixes become available

---

🤖 This PR was created by the Okteto AI Powered by Claude Code