### PR TITLE
Fix CVE-2026-0861 and update trivy scanner image

### DIFF
--- a/.claude/skills/cve-review/skill.md
+++ b/.claude/skills/cve-review/skill.md
@@ -1,0 +1,41 @@
+---
+name: cve-review
+description: Use this skill to review CVEs in the pipeline-runner image
+disable-model-invocation: true
+---
+
+# Fix image CVEs
+
+Fix all vulnerabilities in the pipeline runner Docker image using systematic vulnerability scanning and remediation.
+
+## CONTEXT
+
+- The source code and Dockerfile for this image are in the root folder of the repo
+- The vulnerability scanning script is at `trivy/scan.sh`, referenced by the `okteto test trivy` test container
+- Focus on CRITICAL and HIGH severity vulnerabilities first, then address medium/low as needed
+
+## WORKFLOW
+
+### 1. Build and Scan Process
+
+- Rebuild the image: `okteto build` (do not use `--no-cache` unless necessary)
+- Scan for vulnerabilities: `okteto test trivy`
+- Analyze scan results to identify specific packages and CVEs that need attention
+
+### 2. Vulnerability Remediation
+
+- Repeat the build and scan process after each set of changes
+- Continue until all CRITICAL and HIGH vulnerabilities are resolved or you cannot fix more CVEs
+
+## PULL REQUEST REQUIREMENTS
+
+If you did any change, create a PR for vulnerability fixes
+
+### Required Content
+
+- **Clear status statement**: First line must clearly state whether ALL CRITICAL/HIGH vulnerabilities have been fixed or not
+- **Before/after scans**: Include trivy scan results before and after changes using:
+  ```
+  okteto test trivy
+  ```
+- **Summary of changes**: List specific packages updated, base image changes, etc.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt clean && apt update && \
         jq \
         netcat-traditional && \
     rm -f /etc/ssh/ssh_host_* && \
-    apt -y upgrade gnupg dirmngr gpg gpg-agent gpgconf gpgsm gnupg-l10n openssl libssl3t64 openssl-provider-legacy && \
+    apt -y upgrade gnupg dirmngr gpg gpg-agent gpgconf gpgsm gnupg-l10n openssl libssl3t64 openssl-provider-legacy libc-bin libc6 && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/*
 

--- a/okteto.yml
+++ b/okteto.yml
@@ -4,7 +4,7 @@ build:
 
 test:
   trivy:
-    image: aquasec/trivy:latest
+    image: ghcr.io/aquasecurity/trivy:0.69.3@sha256:7228e304ae0f610a1fad937baa463598cadac0c2ac4027cc68f3a8b997115689
     context: trivy
     caches:
       - /root/.cache/trivy


### PR DESCRIPTION
## Status

**NOT all HIGH/CRITICAL vulnerabilities have been fixed.** 22 HIGH CVEs remain with `affected` or `fix_deferred` status — no upstream fixes are available for them yet. CVE-2026-0861 was fixed (the only one with an available patch).

## Before (24 HIGH, 0 CRITICAL)

```
Total: 24 (HIGH: 24, CRITICAL: 0)
Notable fixable: CVE-2026-0861 (glibc) — fixed at 2.41-12+deb13u2
```

## After (22 HIGH, 0 CRITICAL)

```
Total: 22 (HIGH: 22, CRITICAL: 0)
All remaining: status = affected or fix_deferred (no fix available)
```

## Summary of changes

- **Dockerfile**: Added `libc-bin libc6` to explicit `apt upgrade` list to fix CVE-2026-0861 (glibc integer overflow in memalign, heap corruption). Upgraded from `2.41-12+deb13u1` → `2.41-12+deb13u2`.
- **okteto.yml**: Updated trivy test container image from `aquasec/trivy:latest` (no longer available) to `ghcr.io/aquasecurity/trivy:0.69.3@sha256:7228e304ae0f610a1fad937baa463598cadac0c2ac4027cc68f3a8b997115689`.

## Remaining unfixable CVEs (no upstream patch available)

| CVE | Package(s) | Status |
|-----|-----------|--------|
| CVE-2026-24882 | gnupg family (7 pkgs) | affected |
| CVE-2026-4046 | libc-bin, libc6 | fix_deferred |
| CVE-2026-25210 | libexpat1 | affected |
| CVE-2025-69720 | ncurses (4 pkgs) | affected |
| CVE-2026-27135 | libnghttp2-14 | affected |
| CVE-2026-29111 | systemd (4 pkgs) | affected |
| CVE-2026-3497 | openssh (3 pkgs) | affected |

🤖 Generated with [Claude Code](https://claude.com/claude-code)