### PR TITLE
Build pipeline runner with Depot.dev instead of using product cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,16 @@
 version: 2.1
 alias:
-  - &okteto-login |
-    curl https://get.okteto.com -sSfL | sh
-    mkdir -p $HOME/.okteto
-    touch $HOME/.okteto/.noanalytics
-    okteto context use ${OKTETO_URL} --token ${OKTETO_TOKEN}
   - &docker-login echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
 
 jobs:
   build:
     docker:
-      - image: cimg/base:current
+      - image: okteto/golang-ci:2.9.2
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
-      - run: *okteto-login
       - run: 
           name: Build Rootful Image
           command: make build-rootful
@@ -22,10 +19,12 @@ jobs:
           command: make build-rootless
   release:
     docker:
-      - image: cimg/base:current
+      - image: okteto/golang-ci:2.9.2
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
-      - run: *okteto-login
       - run: *docker-login
       - run:
           name: Build and Push Rootful Image
@@ -39,13 +38,11 @@ workflows:
   build:
     jobs:
       - build:
-          context: Product-okteto-dev
+          context: dockerhub
   release:
     jobs:
       - release:
-          context:
-            - dockerhub
-            - Product-okteto-dev
+          context: dockerhub
           filters:
             branches:
               ignore: /.*/

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build-rootless:
 push: push-rootful
 
 push-rootful:
-	@depot build -t okteto/pipeline-runner:${CIRCLE_TAG} --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .
+	@depot build --push -t okteto/pipeline-runner:${CIRCLE_TAG} --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .
 
 push-rootless:
-	@depot build -t okteto/pipeline-runner:${CIRCLE_TAG}-rootless --platform linux/amd64,linux/arm64 -f Dockerfile --target rootless .
+	@depot build --push -t okteto/pipeline-runner:${CIRCLE_TAG}-rootless --platform linux/amd64,linux/arm64 -f Dockerfile --target rootless .

--- a/Makefile
+++ b/Makefile
@@ -4,22 +4,16 @@ CIRCLE_TAG ?= dev
 build: build-rootful
 
 build-rootful:
-	okteto build --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .
+	@depot build --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .
 
 build-rootless:
-	okteto build --platform linux/amd64,linux/arm64 -f Dockerfile --target rootless .
+	@depot build --platform linux/amd64,linux/arm64 -f Dockerfile --target rootless .
 
 # keep 'push' makefile step rootful for backwards compatibility
 push: push-rootful
 
 push-rootful:
-	okteto build -t okteto/pipeline-runner:${CIRCLE_TAG} --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .
+	@depot build -t okteto/pipeline-runner:${CIRCLE_TAG} --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .
 
 push-rootless:
-	okteto build -t okteto/pipeline-runner:${CIRCLE_TAG}-rootless --platform linux/amd64,linux/arm64 -f Dockerfile --target rootless .
-
-push-dev-rootful:
-	okteto build -t okteto.dev/pipeline-runner:dev --platform linux/amd64,linux/arm64 -f Dockerfile --target rootful .
-
-push-dev-rootless:
-	okteto build -t okteto.dev/pipeline-runner:dev-rootless --platform linux/amd64,linux/arm64 -f Dockerfile --target rootless .
+	@depot build -t okteto/pipeline-runner:${CIRCLE_TAG}-rootless --platform linux/amd64,linux/arm64 -f Dockerfile --target rootless .


### PR DESCRIPTION
Moved the build of the image to use Depot.dev instead of using product cluster to avoid zstd compression. 

Product-okteto-dev context is no longer needed, as the step/alias okteto.login