### PR TITLE
Fix CVEs: update debian:13.5-slim base image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM debian:13.5-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8 AS base
+FROM debian:13.5-slim@sha256:a617c1cdde36a7e0194b2f07dff669e1753c03c3205356b94f9f350b0f9a57d1 AS base
 
 RUN apt clean && apt update && \
     apt -y upgrade && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM debian:13.5-slim@sha256:a617c1cdde36a7e0194b2f07dff669e1753c03c3205356b94f9f350b0f9a57d1 AS base
+FROM debian:13.5-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2 AS base
 
 RUN apt clean && apt update && \
     apt -y upgrade && \


### PR DESCRIPTION
## Status

NOT all CRITICAL/HIGH vulnerabilities are fixed. 44 remain (8 CRITICAL, 36 HIGH), but all have status `affected` or `fix_deferred` — meaning no fixes are available in Debian's package repositories yet.

## Summary

- Updated the pinned `debian:13.5-slim` base image digest from the stale debian 13.2 snapshot (`sha256:b6e2a152...`) to the current debian 13.5 image (`sha256:a617c1cd...`)
- This allowed `apt upgrade` to pull in all available security fixes from Debian's repos

## Before (103 CVEs — 13 CRITICAL, 90 HIGH)

Scan of old image (debian 13.2 snapshot):
```
Total: 103 (HIGH: 90, CRITICAL: 13)
```
Key packages with available fixes that were missing: openssl (3.5.4→3.5.6), libgnutls30t64 (3.8.9-3→3.8.9-3+deb13u4), openssh (10.0p1-7→10.0p1-7+deb13u4), jq (1.7.1-6+deb13u1→+deb13u2), libnghttp2-14, libssh2-1t64, libngtcp2-16, gnupg (2.4.7-21→+deb13u1).

## After (44 CVEs — 8 CRITICAL, 36 HIGH)

```
Total: 44 (HIGH: 36, CRITICAL: 8)
```
All remaining CVEs are `affected` or `fix_deferred` — no upstream Debian fixes available. Affected packages: perl family (CVE-2026-42496, CVE-2026-8376, etc.), curl (CVE-2026-5773, CVE-2026-6276), gnupg (CVE-2026-24882), libexpat1, ncurses, libsqlite3-0, jq (CVE-2026-49839).

## Changes

- `Dockerfile`: updated `debian:13.5-slim` digest from `sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8` to `sha256:a617c1cdde36a7e0194b2f07dff669e1753c03c3205356b94f9f350b0f9a57d1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)