### PR TITLE
ci: bump okteto/golang-ci image to 2.10.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ alias:
 jobs:
   build:
     docker:
-      - image: okteto/golang-ci:2.9.2
+      - image: okteto/golang-ci:2.10.1@sha256:3279c526fdce2272b60979dff352e1e672bf2f8d3035797d96365c619f9c87ab
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -19,7 +19,7 @@ jobs:
           command: make build-rootless
   release:
     docker:
-      - image: okteto/golang-ci:2.9.2
+      - image: okteto/golang-ci:2.10.1@sha256:3279c526fdce2272b60979dff352e1e672bf2f8d3035797d96365c619f9c87ab
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
Bumps the pinned `okteto/golang-ci` CI image from `2.9.2` to the latest release [`2.10.1`](https://github.com/okteto/golang-ci/releases/tag/2.10.1), and adds a `sha256` digest pin (the reference was previously tag-only).

**What** — Updates the `okteto/golang-ci` image in `.circleci/config.yml` (`build` and `release` jobs).

**Why** — golang-ci `2.10.1` upgrades Go to 1.26.5 and refreshes CI tooling (kubectl, yq, trivy, gotestsum, air, depot, okteto). Pinning by digest makes CI runs reproducible and immune to tag re-pushes — matching how the image is pinned in the other okteto repos. Part of an org-wide sweep to keep the `okteto/golang-ci` image reference up to date.

**How** — `okteto/golang-ci:2.9.2` → `okteto/golang-ci:2.10.1@sha256:3279c526fdce2272b60979dff352e1e672bf2f8d3035797d96365c619f9c87ab`. No functional code changes.

## Testing

No repo code changed — only the CI runner image pin. CircleCI runs the `build` job against the new image on this PR. The digest matches the one published for the [2.10.1 release](https://github.com/okteto/golang-ci/releases/tag/2.10.1). (golang-ci is only the CI runner here; the published pipeline-runner image is built via depot, so its contents are unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115oxUS8nc47FefwJEt3Bdi

---
_Generated by [Claude Code](https://claude.ai/code/session_0115oxUS8nc47FefwJEt3Bdi)_